### PR TITLE
Display repo state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ required arguments::
     --version          show program's version number and exit
     -h, --help         show this help message and exit
     -u, --update       update existing repositories
+    -S, --show         display current repository state and exit
     -q, --quiet        suppress output from git command
     -v, --verbose      display more logging info
     -d, --dump-config  dump active configuration file or example to stdout and


### PR DESCRIPTION
* add `--show` command option to display repo tag/hash data
* log the output from `git describe` if current repo state is valid