### PR TITLE
cleanup imports, add changelog in docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: |
+          ./dist/*.whl
           ./dist/*.tar.gz
 
   create_release:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,5 +49,6 @@ jobs:
         if: matrix.python-version == 3.8 && runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: ./dist/*.whl
+          path: |
+            ./dist/*.whl
+            ./dist/*.tar.gz

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,191 @@
+0.4.0 (2022-12-23)
+------------------
+
+New
+~~~
+- Add new config options, update readme and default yaml. [Stephen L
+  Arnold]
+
+  * add option for clone depth with default 0 (ala gh workflows)
+  * add option to install a repo into the current env using pip
+
+Changes
+~~~~~~~
+- Update all workflows, mainly action versions. [Stephen L Arnold]
+
+Fix
+~~~
+- Cleanup/improve docstring for module func. [Stephen L Arnold]
+
+Other
+~~~~~
+- Merge pull request #12 from sarnold/older-python. [Steve Arnold]
+
+  new features and older python
+
+
+0.3.3 (2022-09-29)
+------------------
+
+Fix
+~~~
+- Add missing exit in cmd exception handler. [Stephen L Arnold]
+
+  * inconsistent directory error should exit after log msg
+
+Other
+~~~~~
+- Merge pull request #10 from sarnold/hotfix. [Steve Arnold]
+
+  add missing exit in cmd exception handler
+
+
+0.3.2 (2022-09-29)
+------------------
+
+New
+~~~
+- Flesh out show cmd with branch and describe data. [Stephen L Arnold]
+
+Fix
+~~~
+- Add missing refactor bits, update debug logging. [Stephen L Arnold]
+
+  * remove secondary loop check, make sure repo context is available
+  * add more useful output to show cmd, make sure we fetch tags
+  * add more logging introspection
+
+Other
+~~~~~
+- Merge pull request #9 from sarnold/more-show. [Steve Arnold]
+
+  Show more repo metadata, finish refactor
+
+
+0.3.1 (2022-09-13)
+------------------
+
+New
+~~~
+- Abstract code for valid_repo_state, add new show option. [Stephen L
+  Arnold]
+
+  * for display of current repo state, ie, git describe output
+
+Changes
+~~~~~~~
+- Add new show option to usage output in readme. [Stephen L Arnold]
+
+Fix
+~~~
+- Still more docstring cleanup. [Stephen L Arnold]
+
+Other
+~~~~~
+- Merge pull request #8 from sarnold/repo-state. [Steve Arnold]
+
+  Display repo state
+
+
+0.3.0 (2022-09-04)
+------------------
+
+New
+~~~
+- Add support for submodule update and bandit workflow. [Stephen L
+  Arnold]
+
+  * add submodule handling to repo update cmd
+  * add bandit security check workflow
+  * update docs/docstrings and tool configs
+
+Fix
+~~~
+- Restore missing bits, un-disable some pylint checks. [Stephen L
+  Arnold]
+
+  * add missing recursive arg for submodule update
+  * re-flow readme text, add missing updates
+  * remove pylint-disable comments, update tox file
+
+Other
+~~~~~
+- Merge pull request #7 from sarnold/more-cleanup. [Steve Arnold]
+
+  submodule and doc updates
+- Merge pull request #6 from sarnold/more-subs. [Steve Arnold]
+
+  add support for submodule update
+
+
+0.2.1 (2022-08-31)
+------------------
+
+Changes
+~~~~~~~
+- Main docs TOC meeds a better title. [Stephen L Arnold]
+
+Fix
+~~~
+- Add missing repo branch option. [Stephen L Arnold]
+- Skip existing repos and allow clone if config updated. [Stephen L
+  Arnold]
+
+  * meaning the config file must have at least one repo configured that
+    does not yet exist in the target directory, eg, a new ( or at least
+    newly enabled) repository
+
+Other
+~~~~~
+- Merge pull request #5 from sarnold/new-repo-fix. [Steve Arnold]
+
+  improve existing directory check
+
+
+0.2.0 (2022-08-20)
+------------------
+
+Changes
+~~~~~~~
+- Flesh out table of configuration keys. [Stephen L Arnold]
+
+Other
+~~~~~
+- Merge pull request #3 from sarnold/still-more-docs. [Steve Arnold]
+
+  expand cfg opts, update readme
+
+
+0.1.0 (2022-08-17)
+------------------
+
+New
+~~~
+- Add lock-config option, update default config and readme. [Stephen L
+  Arnold]
+- Add sphinx/api doc sources and ci workflow, more cleanup. [Stephen L
+  Arnold]
+
+  * update readme, add missing license file
+
+Other
+~~~~~
+- Merge pull request #2 from sarnold/more-docs. [Steve Arnold]
+
+  doc updates and cleanup
+- Merge pull request #1 from sarnold/docs-and-ci. [Steve Arnold]
+
+  docs and CI workflows
+- Create readme file, add base github CI workflows, more cleanup.
+  [Stephen L Arnold]
+- Finish initial git cmds, wire up logging, cleanup packaging. [Stephen
+  L Arnold]
+- Apply more flesh and lint cleanup, update cfg and tox files. [Stephen
+  L Arnold]
+- Add more (half)skeleton, update reqs, setup, tox files. [Stephen L
+  Arnold]
+
+
+0.0.0 (2022-08-14)
+------------------
+- Add initial project files and example config. [Stephen L Arnold]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 graft tests
 graft docs
 
-include tox.ini README.rst
+include tox.ini README.rst CHANGELOG.rst
 
 global-exclude *~ *.py[cod]

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,55 @@ via the environment variable ``REPO_CFG``, eg::
   $ $EDITOR repo-develop.yml  # set alternate branches, other options
   $ REPO_CFG="repo-develop.yml" repolite --update
 
+OS Package Install
+------------------
+
+Packages are available for Ubuntu_, and the latest can be installed on
+Gentoo using ``portage`` (or the ebuilds in `this portage overlay`_).
+To build from source, see the `Dev tools`_ section below.
+
+.. _Ubuntu: https://launchpad.net/~nerdboy/+archive/ubuntu/embedded
+.. _this portage overlay: https://github.com/VCTLabs/embedded-overlay/
+
+
+Prerequisites
+~~~~~~~~~~~~~
+
+A supported linux distribution, mainly something that uses either
+``.ebuilds`` (eg, Gentoo or funtoo) or ``.deb`` packages, starting with at
+least Ubuntu bionic or Debian stretch (see the above PPA package repo
+on Launchpad).
+
+On Gentoo, just install the package: ``emerge dev-util/repolite`` otherwise
+on Ubuntu bionic or newer, follow the steps below.
+
+Make sure you have the ``add-apt-repository`` command installed and
+then add the PPA:
+
+::
+
+  $ sudo apt-get install software-properties-common
+  $ sudo add-apt-repository -y -s ppa:nerdboy/embedded
+  $ sudo apt-get install python3-repolite
+
+
+.. note:: Since the package series currently published are for bionic/focal,
+          building from source is recommended if installing on Debian.
+
+
+If you get a key error you will also need to manually import the PPA
+signing key like so:
+
+::
+
+  $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys <PPA_KEY>
+
+where <PPA_KEY> is the key shown in the launchpad PPA page under "Adding
+this PPA to your system", eg, ``41113ed57774ed19`` for `Embedded device ppa`_.
+
+.. _Embedded device ppa: https://launchpad.net/~nerdboy/+archive/ubuntu/embedded
+
+
 Install with pip
 ----------------
 

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -1,0 +1,1 @@
+../../CHANGELOG.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,9 +41,11 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_git',
     'sphinxcontrib.apidoc',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,20 @@
 Welcome to the repolite documentation!
 ======================================
 
-.. toctree::
-   :caption: Contents:
-   :maxdepth: 3
+.. git_commit_detail::
+    :branch:
+    :commit:
+    :sha_length: 10
+    :uncommitted:
+    :untracked:
 
-   README.rst
-   api/modules
+.. toctree::
+    :caption: Contents:
+    :maxdepth: 3
+
+    README
+    api/modules
+    CHANGELOG
 
 
 Indices and tables

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,15 +43,16 @@ console_scripts =
 [options.extras_require]
 doc =
     sphinx
+    sphinx_git
     recommonmark
     sphinx_rtd_theme
     sphinxcontrib-apidoc
 test =
     pytest
-cov =
     pytest-cov
+cov =
+    covdefaults
     coverage[toml]
-    coverage_python_version
 all =
     %(cov)s
     %(doc)s

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
+import os
 import sys
 
-if sys.version_info > (3,6):
+if sys.version_info.minor > 6:
     import setuptools
 
     setuptools.setup()
 else:
     from distutils.core import setup
 
-    pkg_name = 'repolite'
-    sys.path[0:0] = ['src'/pkg_name]
-    from _version import __version__
+    sys.path.append(os.path.abspath("src"))
+    from repolite._version import __version__
+    sys.path.pop()
 
     setup(
-        name=pkg_name,
+        name="repolite",
         version=__version__,
-        packages=[pkg_name],
-        package_dir = {'': 'src'}
+        packages=["repolite"],
+        package_dir={"": "src"},
     )

--- a/src/repolite/repolite.py
+++ b/src/repolite/repolite.py
@@ -22,6 +22,8 @@ from shutil import which
 import pkg_resources
 from munch import Munch
 
+from ._version import __version__
+
 # from logging_tree import printout  # debug logger environment
 
 
@@ -373,7 +375,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv
 
-    parser = OptionParser(usage="usage: %prog [options]", version=f"%prog {VERSION}")
+    parser = OptionParser(usage="usage: %prog [options]", version=f"%prog {__version__}")
     parser.description = 'Manage local (git) dependencies (default: clone and checkout).'
     parser.add_option(
         "-i",
@@ -479,7 +481,6 @@ def main(argv=None):
         logging.error('Top dir: %s', exc)
 
 
-VERSION = pkg_resources.get_distribution('repolite').version
 REPO_CFG = os.getenv('REPO_CFG', default='')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -172,6 +172,9 @@ deps =
     pylint
     -r requirements.txt
 
+commands_pre =
+    {[testenv:docs]commands_pre}
+
 commands =
     pylint --fail-under=9.60 src/repolite/repolite.py
 
@@ -194,6 +197,9 @@ skip_install = true
 
 setenv = PYTHONPATH = {toxinidir}
 
+allowlist_externals =
+    bash
+
 deps =
     {[base]deps}
     mypy
@@ -202,7 +208,7 @@ deps =
 
 commands_pre =
     # need to generate version info in a fresh checkout
-    python setup.py egg_info
+    bash -c '[[ -f src/repolite/_version.py ]] || python setup.py egg_info'
 
 commands =
     #stubgen -m munch --export-less -o {toxinidir}


### PR DESCRIPTION
* remove global VERSION var and just import it directly
* remove "newer" constructs, make setup.py work in PPA bionic build env => old py3.6
* add a CHANGELOG file and include it in docs build
* cleanup ci artifacts