### PR TITLE
add per-repo tag support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,12 +27,12 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload artifacts
         if: matrix.python-version == 3.9 && runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             ./dist/*.whl

--- a/README.rst
+++ b/README.rst
@@ -155,25 +155,30 @@ The current version supports minimal command options and there are no
 required arguments::
 
   (dev) user@host repolite (main) $ repolite -h
-  usage: repolite [-h] [--version] [-v] [-q] [-d] [-s] [-i] [-u] [-S] [-T TAG]
-                  [-l]
+  usage: repolite [-h] [--version] [-v] [-q] [-D] [-S] [-i] [-u] [-s] [-a] [-l]
+                  [TAG]
 
   Manage local (git) dependencies (default: clone and checkout)
+
+  positional arguments:
+    TAG                Tag string override for all repositories (apply with -a)
+                       (default: None)
 
   options:
     -h, --help         show this help message and exit
     --version          show program's version number and exit
     -v, --verbose      Display more processing info (default: False)
     -q, --quiet        Suppress output from git command (default: False)
-    -d, --dump-config  Dump default configuration file to stdout (default:
+    -D, --dump-config  Dump default configuration file to stdout (default:
                        False)
-    -s, --save-config  Save active config to default filename (.ymltoxml.yml)
+    -S, --save-config  Save active config to default filename (.ymltoxml.yml)
                        and exit (default: False)
     -i, --install      Install existing repositories (python only) (default:
                        False)
     -u, --update       Update existing repositories (default: False)
-    -S, --show         Display current repository state (default: False)
-    -T TAG, --tag TAG  Tag string for each configured repository (default: None)
+    -s, --show         Display current repository state (default: False)
+    -a, --apply-tag    Apply the given tag (see TAG arg) or use one from config
+                       file (default: False)
     -l, --lock-config  Lock active configuration in new config file and checkout
                        hashes (default: False)
 
@@ -206,6 +211,7 @@ Configuration keys for optional extra features/behavior:
 Configuration keys that change repository state:
 
 :repo_create_tag_msg: default tag message text
+:repo_create_tag_new: create new tag using string value
 :repo_create_tag_annotated: create an annotated tag (no signature)
 :repo_create_tag_signed: create a signed tag (requires GPG key)
 :repo_push_new_tags: whether or not to push newly created tags
@@ -213,6 +219,7 @@ Configuration keys that change repository state:
 
 Notes:
 
+* when tagging, tag from commandline is only used when config value is ``null``
 * when tagging, ``create_tag_annotated`` and ``create_tag_signed`` are
   mutually exclusive, so only enable one of them
 * use ``--lock-config`` to create a new config file with git hashes, then

--- a/src/repolite/data/example.yml
+++ b/src/repolite/data/example.yml
@@ -12,6 +12,7 @@ repos:
     repo_branch: master
     repo_hash: null
     repo_create_tag_msg: tag for test
+    repo_create_tag_new: null
     repo_create_tag_annotated: false
     repo_create_tag_signed: false
     repo_push_new_tags: false
@@ -30,6 +31,7 @@ repos:
     repo_branch: master
     repo_hash: null
     repo_create_tag_msg: tag for test
+    repo_create_tag_new: null
     repo_create_tag_annotated: false
     repo_create_tag_signed: false
     repo_push_new_tags: false

--- a/tests/test_repolite.py
+++ b/tests/test_repolite.py
@@ -25,6 +25,7 @@ repos:
     repo_branch: main
     repo_hash: null
     repo_create_tag_msg: tag for test
+    repo_create_tag_new: null
     repo_create_tag_annotated: false
     repo_create_tag_signed: false
     repo_push_new_tags: false
@@ -43,6 +44,7 @@ repos:
     repo_branch: branch1
     repo_hash: null
     repo_create_tag_msg: tag for test
+    repo_create_tag_new: null
     repo_create_tag_annotated: false
     repo_create_tag_signed: false
     repo_push_new_tags: false
@@ -162,6 +164,11 @@ def test_repolite_tag(script_loc, tmpdir_session):
     flag_list.append(ulock)
 
     tag = 'v9.9.9'
+    create_repo_tags(cfg, tag)
+    tag = None
+    for repo in cfg.repos:
+        if repo.repo_name == 'daffy':
+            repo.repo_create_tag_new = '1.1.1'
     create_repo_tags(cfg, tag)
 
 


### PR DESCRIPTION
* support per-repo tag in config file for tag creation
* add new config key `repo_create_tag_new`
* repo tag takes precedence over command-line tag
* we also check if provided tag already exists