### PR TITLE
Add changelog support

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -26,8 +26,7 @@ jobs:
 
     - name: Build docs
       run: |
-        tox -e docs-lint
-        tox -e docs
+        tox -e ldocs,docs
 
     - uses: actions/upload-artifact@v4
       with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@ Changelog
 =========
 
 
+0.6.2 (2024-06-01)
+------------------
+
+New
+~~~
+- Add changelog feature for release workflows. [Stephen L Arnold]
+
+  * uses ``gitchangelog`` to generate either full changelog.rst or
+    changelog diff from given base tag
+
+Changes
+~~~~~~~
+- Add config option to set changelog file extension. [Stephen L Arnold]
+
+  * allowed options are 'rst' or 'md' depending on the gitchangelog
+    configuration setting for ``output_engine``
+
+
 0.6.1 (2024-05-22)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ files in yaml instead.
 .. _tox: https://github.com/tox-dev/tox
 .. _pip: https://packaging.python.org/en/latest/key_projects/#pip
 
+The latest new/expanded workflow features now include:
+
+* **tagging support** - tag a set of enabled repositories via config file or
+  command line
+* **changelog support** in ``rSt`` or ``md`` - generate changelog documents
+  for enabled repositories
+
+See the optional feature keys in Usage_ for more info.
 
 Repolite is tested on the 3 primary GH runner platforms, so as long as you
 have a new-ish Python and a ``git`` binary it should run on your platform
@@ -206,7 +214,8 @@ Configuration keys for optional extra features/behavior:
                      (requires ``git-lfs`` to be installed first)
 :repo_init_submodules: if true, initialize/update git submodules in that repository
 :repo_install: if true, try to install the repo with pip_
-:repo_tag_base: base version to use for changelog data
+:repo_changelog_ext: changelog file extension (default: ``rst``)
+:repo_changelog_base: base version to use for changelog data
 :repo_gen_changes: if true, generate changelog file in ``top_dir``
 
 Configuration keys that change repository state:
@@ -220,6 +229,8 @@ Configuration keys that change repository state:
 
 Notes:
 
+* if your gitchangelog_ config uses Markdown, set ``repo_changelog_ext`` to
+  ``md`` instead of ``rst``
 * when tagging, tag from commandline is only used when config value is ``null``
 * when tagging, ``create_tag_annotated`` and ``create_tag_signed`` are
   mutually exclusive, so only enable one of them
@@ -237,6 +248,7 @@ Notes:
 * you may want to add your ``top_dir`` path or default local config file
   patterns to your ``.gitignore`` file
 
+.. _gitchangelog: https://github.com/sarnold/gitchangelog
 
 Dev tools
 =========

--- a/README.rst
+++ b/README.rst
@@ -155,32 +155,31 @@ The current version supports minimal command options and there are no
 required arguments::
 
   (dev) user@host repolite (main) $ repolite -h
-  usage: repolite [-h] [--version] [-v] [-q] [-D] [-S] [-i] [-u] [-s] [-a] [-l]
+  usage: repolite [-h] [--version] [-v] [-q] [-D] [-S] [-i] [-u] [-s] [-a] [-g] [-l]
                   [TAG]
 
   Manage local (git) dependencies (default: clone and checkout)
 
   positional arguments:
-    TAG                Tag string override for all repositories (apply with -a)
-                       (default: None)
+    TAG                Optional tag string override (apply with -a) (default: None)
 
   options:
     -h, --help         show this help message and exit
     --version          show program's version number and exit
     -v, --verbose      Display more processing info (default: False)
     -q, --quiet        Suppress output from git command (default: False)
-    -D, --dump-config  Dump default configuration file to stdout (default:
-                       False)
-    -S, --save-config  Save active config to default filename (.ymltoxml.yml)
-                       and exit (default: False)
-    -i, --install      Install existing repositories (python only) (default:
-                       False)
-    -u, --update       Update existing repositories (default: False)
+    -D, --dump-config  Dump default configuration file to stdout (default: False)
+    -S, --save-config  Save active config to default filename (.ymltoxml.yml) and exit
+                       (default: False)
+    -i, --install      Install enabled repositories (python only) (default: False)
+    -u, --update       Update existing/enabled repositories (default: False)
     -s, --show         Display current repository state (default: False)
-    -a, --apply-tag    Apply the given tag (see TAG arg) or use one from config
-                       file (default: False)
-    -l, --lock-config  Lock active configuration in new config file and checkout
-                       hashes (default: False)
+    -a, --apply-tag    Apply the given tag (see TAG arg) or use one from config file
+                       (default: False)
+    -g, --changelog    Run gitchangelog in enabled repositories, create files in top_dir
+                       (default: False)
+    -l, --lock-config  Lock active configuration in new config file and checkout hashes
+                       (default: False)
 
 Configuration settings
 ----------------------
@@ -207,6 +206,8 @@ Configuration keys for optional extra features/behavior:
                      (requires ``git-lfs`` to be installed first)
 :repo_init_submodules: if true, initialize/update git submodules in that repository
 :repo_install: if true, try to install the repo with pip_
+:repo_tag_base: base version to use for changelog data
+:repo_gen_changes: if true, generate changelog file in ``top_dir``
 
 Configuration keys that change repository state:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-munch
+gitchangelog @ https://github.com/sarnold/gitchangelog/releases/download/3.2.0/gitchangelog-3.2.0-py3-none-any.whl
+importlib-metadata; python_version < '3.8'
+importlib-resources; python_version < '3.10'
+munch[yaml]
 PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ setup_requires =
     setuptools_scm[toml]
 
 install_requires =
+    gitchangelog @ https://github.com/sarnold/gitchangelog/releases/download/3.2.0/gitchangelog-3.2.0-py3-none-any.whl
     importlib-metadata; python_version < '3.8'
     importlib-resources; python_version < '3.10'
     munch[yaml]

--- a/src/repolite/data/example.yml
+++ b/src/repolite/data/example.yml
@@ -17,7 +17,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
-    repo_change_base: null
+    repo_changelog_ext: rst
+    repo_changelog_base: null
     repo_gen_changes: false
     repo_use_rebase: false
     repo_has_lfs_files: false
@@ -38,7 +39,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
-    repo_change_base: null
+    repo_changelog_ext: rst
+    repo_changelog_base: null
     repo_gen_changes: false
     repo_use_rebase: false
     repo_has_lfs_files: false

--- a/src/repolite/data/example.yml
+++ b/src/repolite/data/example.yml
@@ -17,6 +17,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
+    repo_change_base: null
+    repo_gen_changes: false
     repo_use_rebase: false
     repo_has_lfs_files: false
     repo_init_submodules: false
@@ -36,6 +38,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
+    repo_change_base: null
+    repo_gen_changes: false
     repo_use_rebase: false
     repo_has_lfs_files: false
     repo_init_submodules: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ git_cmd = [
     'git_dummy',
     '--allow-nested',
     '--constant-sha',
+    '--commits=10',
     '--branches=5',
     '--diverge-at=2',
     '--git-dir',

--- a/tests/test_repolite.py
+++ b/tests/test_repolite.py
@@ -30,6 +30,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
+    repo_change_base: null
+    repo_gen_changes: true
     repo_use_rebase: false
     repo_has_lfs_files: false
     repo_init_submodules: false
@@ -49,6 +51,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
+    repo_change_base: null
+    repo_gen_changes: true
     repo_use_rebase: false
     repo_has_lfs_files: false
     repo_init_submodules: false
@@ -201,3 +205,27 @@ def test_repolite_locked_cfg(tmp_path, script_loc, tmpdir_session):
     update = False
     quiet = False
     create_locked_cfg(cfg, pfile, quiet, tpath)
+
+
+def test_repolite_changes(script_loc, tmpdir_session):
+    """
+    Show the repos in the test config.
+    """
+    cfg.top_dir = str(tmpdir_session / 'ext')
+
+    for repo in cfg.repos:
+        pure_path = PurePath(script_loc, 'testdata', repo.repo_url)
+        # print(f'PurePath is {pure_path}')
+        full_path = Path(pure_path).resolve()
+        # print(f'Type is {type(full_path)}')
+        # print(f'Path is {full_path}')
+        print(f'Path string is {full_path.__str__()}')
+        repo.repo_url = full_path.__str__()
+        # print(f'Munch type is {type(repo.repo_url)}')
+        # print(f'Munch value is {repo.repo_url}')
+
+    process_repo_changes(cfg)
+    changelogs = list(Path(cfg.top_dir).glob('**/*.rst'))
+    for fpath in changelogs:
+        print(fpath)
+        assert 'CHANGELOG.rst' in str(fpath)

--- a/tests/test_repolite.py
+++ b/tests/test_repolite.py
@@ -30,7 +30,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
-    repo_change_base: null
+    repo_changelog_ext: rst
+    repo_changelog_base: null
     repo_gen_changes: true
     repo_use_rebase: false
     repo_has_lfs_files: false
@@ -51,7 +52,8 @@ repos:
     repo_create_tag_signed: false
     repo_push_new_tags: false
     repo_signing_key: null
-    repo_change_base: null
+    repo_changelog_ext: rst
+    repo_changelog_base: null
     repo_gen_changes: true
     repo_use_rebase: false
     repo_has_lfs_files: false

--- a/tox.ini
+++ b/tox.ini
@@ -177,41 +177,30 @@ deps =
 commands =
     bash -c 'gitchangelog {posargs} > CHANGELOG.rst'
 
-[testenv:docs]
+[testenv:{docs,ldocs,cdocs}]
+# these tox env cmds share a virtual env using the following plugin
+# https://github.com/masenf/tox-ignore-env-name-mismatch
+envdir = {toxworkdir}/docs
+runner = ignore_env_name_mismatch
 skip_install = true
+
+description =
+    docs: Build the docs using sphinx
+    ldocs: Lint the docs (mainly link checking)
+    cdocs: Clean the docs build artifacts
+
 allowlist_externals =
-    bash
     make
+    bash
 
 deps =
     {[base]deps}
     .[doc]
 
-commands = make -C docs html
-
-[testenv:docs-clean]
-skip_install = true
-allowlist_externals =
-    bash
-    make
-
-deps =
-    {[base]deps}
-    .[doc]
-
-commands = make -C docs clean
-
-[testenv:docs-lint]
-skip_install = true
-allowlist_externals =
-    bash
-    make
-
-deps =
-    {[base]deps}
-    .[doc]
-
-commands = make -C docs linkcheck
+commands =
+    docs: make -C docs html
+    ldocs: make -C docs linkcheck
+    cdocs: make -C docs clean
 
 [testenv:build]
 skip_install = true


### PR DESCRIPTION
Add dependency and configuration options to run gitchangelog on enabled repositories.  Generates either a full changelog or diff file from a base tag.