### PR TITLE
fix docs release error in sphinx linkcheck

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Build docs
       run: |
-        tox -e docs-lint
+        tox -e ldocs
         tox -e docs
 
     - uses: actions/upload-artifact@v4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,11 @@ apidoc_output_dir = 'api'
 apidoc_excluded_paths = ['tests']
 apidoc_separate_modules = True
 
+linkcheck_ignore = [
+    "https://github.com/VCTLabs/vct-asterisk-dev-artifacts/blob/develop/.repolite.yml",
+    "git@github.com:sarnold/repolite/commit/*",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/tox.ini
+++ b/tox.ini
@@ -182,7 +182,6 @@ commands =
 # https://github.com/masenf/tox-ignore-env-name-mismatch
 envdir = {toxworkdir}/docs
 runner = ignore_env_name_mismatch
-skip_install = true
 
 description =
     docs: Build the docs using sphinx


### PR DESCRIPTION
* use the right cmd for linkcheck and ignore 2 urls
  * one is from sphinx_git latest hash using ssh URL
  * the other is just a spurious error for a github URL that definitely *does* exist